### PR TITLE
Update abelsiqueira/COPIERTemplate.jl to JuliaBesties/BestieTemplate.jl

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -9,4 +9,4 @@ PackageName: TimerNLPModels
 PackageOwner: tmigot
 PackageUUID: dcfb2d1f-5e2a-5d7d-93fa-0656abb5c718
 _commit: v0.6.1
-_src_path: https://github.com/abelsiqueira/COPIERTemplate.jl
+_src_path: https://github.com/JuliaBesties/BestieTemplate.jl


### PR DESCRIPTION
This is a semi-automated PR.
BestieTemplate.jl has been moved to the JuliaBesties organization.
This updates the URL in .copier-answers.yml to point to the new location.
